### PR TITLE
Add assertions on Vector3i

### DIFF
--- a/addons/simple-test-harness/src-test/core/assertion/assert_that_vector3i_test.gd
+++ b/addons/simple-test-harness/src-test/core/assertion/assert_that_vector3i_test.gd
@@ -1,0 +1,104 @@
+extends TestCase
+
+#------------------------------------------
+# Test setup
+#------------------------------------------
+
+var _assertion_reporter:AssertionReporter
+
+# Called before each test
+func beforeEach() -> void:
+	_assertion_reporter = AssertionReporter.new("any")
+
+#------------------------------------------
+# Tests
+#------------------------------------------
+
+func test_is_null() -> void:
+	_local_assert_that_vector3i(null).is_null()
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(Vector3i()).is_null()
+	assert_true(_assertion_reporter.has_failures())
+
+func test_is_not_null() -> void:
+	_local_assert_that_vector3i(Vector3i()).is_not_null()
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(null).is_not_null()
+	assert_true(_assertion_reporter.has_failures())
+
+func test_is_equal_to() -> void:
+	_local_assert_that_vector3i(Vector3i()).is_equal_to(Vector3i())
+	_local_assert_that_vector3i(Vector3i(1, 1, 1)).is_equal_to(Vector3i(1, 1, 1))
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(null).is_equal_to(Vector3i())
+	assert_true(_assertion_reporter.has_failures())
+	_assertion_reporter.reset()
+	_local_assert_that_vector3i(Vector3i(1, 2, 3)).is_equal_to(Vector3i(2, 1, 3))
+	assert_true(_assertion_reporter.has_failures())
+
+func test_is_not_equal_to() -> void:
+	_local_assert_that_vector3i(Vector3i()).is_not_equal_to(Vector3i(1, 0, 0))
+	_local_assert_that_vector3i(Vector3i(1, 1, 1)).is_not_equal_to(Vector3i(2, 1, 1))
+	_local_assert_that_vector3i(null).is_not_equal_to(Vector3i())
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(Vector3i()).is_not_equal_to(Vector3i())
+	assert_true(_assertion_reporter.has_failures())
+	_assertion_reporter.reset()
+	_local_assert_that_vector3i(Vector3i(1, 2, 3)).is_not_equal_to(Vector3i(1, 2, 3))
+	assert_true(_assertion_reporter.has_failures())
+
+func test_has_x() -> void:
+	_local_assert_that_vector3i(Vector3i()).has_x(0)
+	_local_assert_that_vector3i(Vector3i(1, 2, 3)).has_x(1)
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(null).has_x(0)
+	assert_true(_assertion_reporter.has_failures())
+	_assertion_reporter.reset()
+	_local_assert_that_vector3i(Vector3i(1, 2, 3)).has_x(3)
+	assert_true(_assertion_reporter.has_failures())
+
+func test_has_y() -> void:
+	_local_assert_that_vector3i(Vector3i()).has_y(0)
+	_local_assert_that_vector3i(Vector3i(2, 1, 3)).has_y(1)
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(null).has_y(0)
+	assert_true(_assertion_reporter.has_failures())
+	_assertion_reporter.reset()
+	_local_assert_that_vector3i(Vector3i(2, 1, 3)).has_y(3)
+	assert_true(_assertion_reporter.has_failures())
+
+func test_has_z() -> void:
+	_local_assert_that_vector3i(Vector3i()).has_z(0)
+	_local_assert_that_vector3i(Vector3i(2, 1, 3)).has_z(3)
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(null).has_z(0)
+	assert_true(_assertion_reporter.has_failures())
+	_assertion_reporter.reset()
+	_local_assert_that_vector3i(Vector3i(2, 1, 3)).has_z(1)
+	assert_true(_assertion_reporter.has_failures())
+
+func test_has_approx_length() -> void:
+	_local_assert_that_vector3i(Vector3i()).has_approx_length(0)
+	_local_assert_that_vector3i(Vector3i(1, 0, 1)).has_approx_length(sqrt(2))
+	assert_false(_assertion_reporter.has_failures())
+
+	_local_assert_that_vector3i(null).has_approx_length(0)
+	assert_true(_assertion_reporter.has_failures())
+	_assertion_reporter.reset()
+	_local_assert_that_vector3i(Vector3i(1, 1, 1)).has_approx_length(2)
+	assert_true(_assertion_reporter.has_failures())
+
+
+#------------------------------------------
+# Helpers
+#------------------------------------------
+
+func _local_assert_that_vector3i(value) -> AssertThatVector3i:
+	return AssertThatVector3i.new(value, _assertion_reporter)

--- a/addons/simple-test-harness/src/core/assertion/assert_that_vector3i.gd
+++ b/addons/simple-test-harness/src/core/assertion/assert_that_vector3i.gd
@@ -1,0 +1,91 @@
+class_name AssertThatVector3i
+extends BaseAssert
+
+#------------------------------------------
+# Signaux
+#------------------------------------------
+
+#------------------------------------------
+# Exports
+#------------------------------------------
+
+#------------------------------------------
+# Variables publiques
+#------------------------------------------
+
+#------------------------------------------
+# Variables privées
+#------------------------------------------
+
+var _assert_that:AssertThat
+
+#------------------------------------------
+# Fonctions Godot redéfinies
+#------------------------------------------
+
+func _init(value:Variant, reporter:AssertionReporter) -> void:
+    super._init(value, reporter)
+    _assert_that = AssertThat.new(value, reporter)
+
+    assert(value == null or value is Vector3i, "Expected null or Vector3i value in AssertThatVector3i")
+
+#------------------------------------------
+# Fonctions publiques
+#------------------------------------------
+
+func is_null() -> AssertThatVector3i:
+    _assert_that.is_null()
+    return self
+
+func is_not_null() -> AssertThatVector3i:
+    _assert_that.is_not_null()
+    return self
+
+func is_equal_to(expected:Vector3i) -> AssertThatVector3i:
+    _assert_that.is_equal_to(expected)
+    return self
+
+func is_not_equal_to(expected:Vector3i) -> AssertThatVector3i:
+    _assert_that.is_not_equal_to(expected)
+    return self
+
+func has_x(expected:int) -> AssertThatVector3i:
+    _do_report( \
+        func(): return _value != null and _value.x == expected, \
+        "Vector3i has x value %s" % expected, \
+        "Expected Vector3i to have x value %s, got %s" % [expected, null if _value == null else _value.x]
+    )
+    return self
+
+func has_y(expected:int) -> AssertThatVector3i:
+    _do_report( \
+        func(): return _value!= null and _value.y == expected, \
+        "Vector3i has y value %s" % expected, \
+        "Expected Vector3i to have y value %s, got %s" % [expected, null if _value == null else _value.y]
+    )
+    return self
+
+func has_z(expected:int) -> AssertThatVector3i:
+    _do_report( \
+        func(): return _value!= null and _value.z == expected, \
+        "Vector3i has z value %s" % expected, \
+        "Expected Vector3i to have z value %s, got %s" % [expected, null if _value == null else _value.z]
+    )
+    return self
+
+func has_approx_length(expected:float, delta:float = 0.000001) -> AssertThatVector3i:
+    _do_report( \
+        func():
+            if _value == null:
+                return false
+            var length:float = _value.length()
+            return length >= expected - delta and length <= expected + delta, \
+        "Vector3i length is %s (delta : %s)" % [expected, delta], \
+        "Expected Vector3i length to be approximatively %s (delta: %s), got %s" % [expected, delta, null if _value == null else _value.length()]
+    )
+    return self
+
+#------------------------------------------
+# Fonctions privées
+#------------------------------------------
+

--- a/addons/simple-test-harness/src/core/test_case/test_case.gd
+++ b/addons/simple-test-harness/src/core/test_case/test_case.gd
@@ -110,6 +110,10 @@ func assert_that_vector2(value:Variant) -> AssertThatVector2:
 func assert_that_vector3(value:Variant) -> AssertThatVector3:
     return AssertThatVector3.new(value, _reporter)
 
+# To test null values, we need to stuck to Variant and not Vector3i, as Vector3i can not be null !
+func assert_that_vector3i(value:Variant) -> AssertThatVector3i:
+    return AssertThatVector3i.new(value, _reporter)
+
 # AWAIT
 func await_for(description:String = "") -> AwaitFor:
     return AwaitFor.new(_reporter, description)


### PR DESCRIPTION
Same logic as Vector3 but : 
- ``is_equal_to() ``and ``is_not_equal_to()`` instead of ``exactly`` and ``approx`` functions as it doesn't make sens for integers.
- replace ``has_exactly_x y and z`` methods by ``has_x`` for the same reason.
- no ``is_finite()`` and ``normalized()`` methods in ``Vector3i``
